### PR TITLE
Fix GZip compression in GetStream method

### DIFF
--- a/Frends.AzureBlobStorage.UploadBlob/CHANGELOG.md
+++ b/Frends.AzureBlobStorage.UploadBlob/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [2.1.1] - 2024-12-05
+## [2.2.0] - 2024-12-05
 ### Updated
 - Fixed GZip compression
 

--- a/Frends.AzureBlobStorage.UploadBlob/CHANGELOG.md
+++ b/Frends.AzureBlobStorage.UploadBlob/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.1.1] - 2024-12-05
+### Updated
+- Fixed GZip compression
+
 ## [2.1.0] - 2024-08-21
 ### Updated
 - Updated Azure.Identity to version 1.12.0.

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.csproj
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>2.1.0</Version>
+	<Version>2.1.1</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.csproj
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>2.1.1</Version>
+	<Version>2.2.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/UploadBlob.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/UploadBlob.cs
@@ -419,31 +419,29 @@ public class AzureBlobStorage
 
             if (!compress)
             {
-                using (var reader = new StreamReader(fileStream, encoding)) bytes = encoding.GetBytes(reader.ReadToEnd());
+                using var reader = new StreamReader(fileStream, encoding);
+                bytes = encoding.GetBytes(reader.ReadToEnd());
                 return new MemoryStream(bytes);
             }
 
             using var outStream = new MemoryStream();
-            using var gzip = new GZipStream(outStream, CompressionMode.Compress);
-
-            if (!fromString)
+            using (var gzip = new GZipStream(outStream, CompressionMode.Compress, true))
             {
-                fileStream.CopyTo(gzip);
-            }
-            else
-            {
-                using var reader = new StreamReader(fileStream, encoding);
-                var content = reader.ReadToEnd();
-                using var encodedMemory = new MemoryStream(encoding.GetBytes(content));
-                encodedMemory.CopyTo(gzip);
+                if (!fromString)
+                {
+                    fileStream.CopyTo(gzip);
+                }
+                else
+                {
+                    using var reader = new StreamReader(fileStream, encoding);
+                    var content = reader.ReadToEnd();
+                    using var encodedMemory = new MemoryStream(encoding.GetBytes(content));
+                    encodedMemory.CopyTo(gzip);
+                }
             }
 
             bytes = outStream.ToArray();
-
-            fileStream.Close();
-
-            var memStream = new MemoryStream(bytes);
-            return memStream;
+            return new MemoryStream(bytes);
         }
         finally
         {


### PR DESCRIPTION
issue [90](https://github.com/FrendsPlatform/Frends.AzureBlobStorage/issues/90)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Version 2.2.0 released, enhancing GZip compression support.
	- Added a new test case for uploading compressed files.

- **Bug Fixes**
	- Improved error handling and resource management in the upload process.
	- Restructured error handling for clearer exception messages during file uploads.

- **Documentation**
	- Updated changelog to reflect historical context and recent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->