### PR TITLE
Updated the UploadBlob task to use a streaming approach instead of re…

### DIFF
--- a/Frends.AzureBlobStorage.UploadBlob/CHANGELOG.md
+++ b/Frends.AzureBlobStorage.UploadBlob/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [3.1.0] - 2025-08-26
+### Changed
+- Updated the UploadBlob task to use a streaming approach (GetStream) instead of reading the entire file into memory (GetBytes), fixing corruption issues with large files; added unit tests to verify integrity for small and 200?MB files.
+
 ## [3.0.0] - 2025-04-16
 ### Changed
 - [Breaking] Reorganized and renamed parameters for clarity and consistency

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.Tests/UnitTests.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.Tests/UnitTests.cs
@@ -6,6 +6,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.IO.Compression;
+using System.Security.Cryptography;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Frends.AzureBlobStorage.UploadBlob.Tests;
@@ -721,6 +723,142 @@ public class UnitTests
         _input.SourceType = UploadSourceType.Directory;
         result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
         Assert.IsFalse(result.Success);
+    }
+
+    [Test]
+    [TestCase(10 * 1024, "small_no_compress.dat")]
+    [TestCase(200L * 1024 * 1024, "large_no_compress.dat")]
+    public async Task UploadDownload_NoCompression_VerifyIntegrity(long fileSize, string fileName)
+    {
+        var tempDir = Path.GetTempPath();
+        var originalFile = Path.Combine(tempDir, "original_" + fileName);
+        var downloadedFile = Path.Combine(tempDir, "downloaded_" + fileName);
+
+        await GenerateRandomFile(originalFile, fileSize);
+        var originalHash = await CalculateSHA256(originalFile);
+        var originalSize = new FileInfo(originalFile).Length;
+
+        var input = new Input
+        {
+            SourceType = UploadSourceType.File,
+            SourceFile = originalFile,
+            BlobName = fileName,
+            Compress = false,
+            ContentsOnly = false,
+            ActionOnExistingFile = OnExistingFile.Overwrite
+        };
+
+        var options = new Options
+        {
+            ThrowErrorOnFailure = true,
+            BlobType = AzureBlobType.Block,
+            ResizeFile = default,
+            PageMaxSize = default,
+            PageOffset = default,
+            ContentType = null,
+            Encoding = FileEncoding.UTF8,
+            EnableBom = false,
+            ParallelOperations = default
+        };
+
+        var uploadResult = await AzureBlobStorage.UploadBlob(input, _connection, options, default);
+        Assert.That(uploadResult.Success, Is.True, "Upload failed");
+
+        await DownloadBlobSimple(_connection.ConnectionString, _containerName, fileName, downloadedFile);
+        var downloadedSize = new FileInfo(downloadedFile).Length;
+        var downloadedHash = await CalculateSHA256(downloadedFile);
+
+        Assert.That(downloadedSize, Is.EqualTo(originalSize),
+            $"File size changed: {originalSize} -> {downloadedSize}");
+        Assert.That(BitConverter.ToString(downloadedHash),
+            Is.EqualTo(BitConverter.ToString(originalHash)),
+            "File content corrupted");
+    }
+
+    [Test]
+    [TestCase(10 * 1024, "small_with_compress.dat")]
+    [TestCase(200L * 1024 * 1024, "large_with_compress.dat")]
+    public async Task UploadDownload_WithCompression_VerifyIntegrity(long fileSize, string fileName)
+    {
+        var tempDir = Path.GetTempPath();
+        var originalFile = Path.Combine(tempDir, "original_" + fileName);
+        var downloadedFile = Path.Combine(tempDir, "downloaded_" + fileName);
+
+        await GenerateRandomFile(originalFile, fileSize);
+        var originalHash = await CalculateSHA256(originalFile);
+
+        var input = new Input
+        {
+            SourceType = UploadSourceType.File,
+            SourceFile = originalFile,
+            BlobName = fileName,
+            Compress = true,
+            ContentsOnly = false,
+            ActionOnExistingFile = OnExistingFile.Overwrite
+        };
+
+        var options = new Options
+        {
+            ThrowErrorOnFailure = true,
+            BlobType = AzureBlobType.Block,
+            ResizeFile = default,
+            PageMaxSize = default,
+            PageOffset = default,
+            ContentType = null,
+            Encoding = FileEncoding.UTF8,
+            EnableBom = false,
+            ParallelOperations = default
+        };
+
+        var uploadResult = await AzureBlobStorage.UploadBlob(input, _connection, options, default);
+        Assert.That(uploadResult.Success, Is.True, "Upload failed");
+
+        await DownloadBlobSimple(_connection.ConnectionString, _containerName, fileName, downloadedFile);
+        using (var inputStream = File.OpenRead(downloadedFile))
+        using (var gzip = new GZipStream(inputStream, CompressionMode.Decompress))
+        using (var outFile = File.Create(downloadedFile + ".decompressed"))
+        {
+            await gzip.CopyToAsync(outFile);
+        }
+
+        var downloadedHash = await CalculateSHA256(downloadedFile + ".decompressed");
+
+        bool hashesMatch = BitConverter.ToString(downloadedHash) == BitConverter.ToString(originalHash);
+        Assert.That(BitConverter.ToString(downloadedHash),
+            Is.EqualTo(BitConverter.ToString(originalHash)),
+            "Downloaded content doesn't match original");
+    }
+
+    private async Task GenerateRandomFile(string filePath, long fileSize)
+    {
+        var rnd = new Random();
+        using var fs = new FileStream(filePath, FileMode.Create, FileAccess.Write);
+        var buffer = new byte[81920];
+        long written = 0;
+
+        while (written < fileSize)
+        {
+            rnd.NextBytes(buffer);
+            int toWrite = (int)Math.Min(buffer.Length, fileSize - written);
+            await fs.WriteAsync(buffer, 0, toWrite);
+            written += toWrite;
+        }
+    }
+
+    private Task<byte[]> CalculateSHA256(string filePath)
+    {
+        return Task.Run(() =>
+        {
+            using var stream = File.OpenRead(filePath);
+            using var sha = SHA256.Create();
+            return sha.ComputeHash(stream);
+        });
+    }
+
+    public static async Task DownloadBlobSimple(string connectionString, string containerName, string blobName, string destinationPath, CancellationToken cancellationToken = default)
+    {
+        var blobClient = new BlobContainerClient(connectionString, containerName).GetBlobClient(blobName);
+        await blobClient.DownloadToAsync(destinationPath, cancellationToken);
     }
 
     private static BlobContainerClient GetBlobContainer(string connectionString, string containerName)

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Definitions/Input.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Definitions/Input.cs
@@ -65,7 +65,9 @@ public class Input
     public bool ContentsOnly { get; set; }
 
     /// <summary>
-    /// Gzip compression only works when transferring stream content (see Input.ContentsOnly).
+    /// If true, the file content will be uploaded using Gzip compression. 
+    /// When ContentsOnly is false, the raw file bytes are compressed. 
+    /// When ContentsOnly is true, the file is read as text using the given encoding before compression.
     /// Note that it could be a good idea to rename the blob using Destination.BlobName (e.g., renaming 'examplefile.txt' to 'examplefile.gz') so that the blob won't be named as 'examplefile.txt.gz
     /// </summary>
     /// <example>false</example>

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.csproj
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<TargetFrameworks>net6.0</TargetFrameworks>
-	<Version>3.0.0</Version>
+	<Version>3.1.0</Version>
 	<Authors>Frends</Authors>
 	<Copyright>Frends</Copyright>
 	<Company>Frends</Company>


### PR DESCRIPTION
…ading the entire file into memory

[]# Frends Task Pull Request

## Summary
<!-- Brief description of changes -->

## Review Checklist

### 1. Frends Task Project Files
- Path: `Frends.*/Frends.*/*.csproj`
- [ ] Targets .NET 8
- [ ] Uses MIT license (`<PackageLicenseExpression>MIT</PackageLicenseExpression>`)
- [ ] Contains required fields:
  - [ ] `<Version>`
  - [ ] `<Authors>Frends</Authors>`
  - [ ] `<Description>`
  - [ ] `<RepositoryUrl>`
  - [ ] `<GenerateDocumentationFile>true</GenerateDocumentationFile>`

### 2. File: FrendsTaskMetadata.json
- [ ] Present: `Frends.*/Frends.*/FrendsTaskMetadata.json`
- [ ] FrendsTaskMetadata.json contains correct task method reference
- [ ] FrendsTaskMetadata.json is included in the project nuget package with path = "/"

### 3. File: README.md
- [ ] Present: `Frends.*/README.md`
- [ ] Contains badges (build, license, coverage)
- [ ] Includes developer setup instructions
- [ ] Does not include parameter descriptions

### 4. File: CHANGELOG.md
- [ ] Present: `Frends.*/CHANGELOG.md`
- [ ] Includes all functional changes
- [ ] Indicates breaking changes with upgrade notes
- [ ] Avoids non-functional notes like "refactored xyz"
- [ ] CHANGELOG.md is included in the project nuget package with path = "/"

### 5. File: migration.json
- [ ] Present: `Frends.*/Frends.*/migration.json`
- [ ] Contains breaking change migration information for Frends, if breaking changes exist
- [ ] migration.json is included in the project nuget package with path = "/"

### 6. Source Code Documentation
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Every public method and class has:
  - [ ] `<summary>` XML comments
  - [ ] `<example>` XML comments
  - [ ] Optionally `<frendsdocs>` XML comments, if needed
- [ ] Follows Microsoft C# code conventions
- [ ] Uses semantic task result documentation (Success, Error, Data)

### 7. GitHub Actions Workflows
- Path: `.github/workflows/*.yml`
- [ ] Task has required workflow files:
  - [ ] `*_test.yml`
  - [ ] `*_main.yml`
  - [ ] `*_release.yml`
- [ ] Correct workdir pointing to task folder
- [ ] Docker setup included if task depends on external system (docker-compose.yml)

### 8. Task Result Object Structure
- Path: `Frends.*/Frends.*/*.cs`
- [ ] Category attribute is present, if applicable
- [ ] All task result classes include:
  - [ ] `Success` (bool)
  - [ ] Task-specific return value (e.g., Data, FilePaths), if needed
  - [ ] Error object with Message and AdditionalInfo
- [ ] Result structure is flat and simple
- [ ] Does not use 3rd-party types
- [ ] Uses dynamic JToken only when structure is unknown


---

## Additional Notes
<!-- Any additional information for reviewers -->
