### PR TITLE
add struc preser option

### DIFF
--- a/Frends.AzureBlobStorage.UploadBlob/CHANGELOG.md
+++ b/Frends.AzureBlobStorage.UploadBlob/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.2.0] - 2026-05-26
+
+### Added
+
+- New option to preserve directory structure when uploading a directory to Azure Blob Storage.
+
 ## [4.1.0] - 2026-05-07
 
 ### Fix

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.Tests/UnitTests.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.Tests/UnitTests.cs
@@ -777,46 +777,6 @@ public class UnitTests
     }
 
     [Test]
-    public async Task UploadDirectory_PreserveStructure_False_WithBlobFolderName()
-    {
-        var testStructureDir = Path.Combine(_testFileDir, "NestedStructure");
-
-        foreach (var blobtype in _blobtypes)
-        {
-            CreateNestedTestStructure(testStructureDir);
-            _options.BlobType = blobtype;
-            _options.PreserveDirectoryStructure = false;
-
-            if (blobtype is AzureBlobType.Page)
-                _options.ResizeFile = true;
-
-            _input.SourceType = UploadSourceType.Directory;
-            _input.SourceDirectory = testStructureDir;
-            _input.SourceFile = default;
-            _input.BlobFolderName = "MyPrefix";
-
-            var container = GetBlobContainer(TestHelper.ConnectionString, _containerName);
-            var result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
-            Assert.IsTrue(result.Success);
-
-            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/MyPrefix/NestedStructure/level1file.txt"));
-            Assert.IsTrue(await container.GetBlobClient("MyPrefix/NestedStructure/level1file.txt").ExistsAsync(),
-                "MyPrefix/NestedStructure/level1file.txt should exist");
-
-            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/MyPrefix/sub1/level2file.txt"));
-            Assert.IsTrue(await container.GetBlobClient("MyPrefix/sub1/level2file.txt").ExistsAsync(),
-                "MyPrefix/sub1/level2file.txt should exist");
-
-            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/MyPrefix/sub2/level3file.txt"));
-            Assert.IsTrue(await container.GetBlobClient("MyPrefix/sub2/level3file.txt").ExistsAsync(),
-                "MyPrefix/sub2/level3file.txt should exist");
-
-            await CleanUp();
-            TestSetup();
-        }
-    }
-
-    [Test]
     public async Task UploadBlob_TestEncoding()
     {
         var encodings = new List<FileEncoding>()

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.Tests/UnitTests.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.Tests/UnitTests.cs
@@ -777,6 +777,46 @@ public class UnitTests
     }
 
     [Test]
+    public async Task UploadDirectory_PreserveStructure_False_WithBlobFolderName()
+    {
+        var testStructureDir = Path.Combine(_testFileDir, "NestedStructure");
+
+        foreach (var blobtype in _blobtypes)
+        {
+            CreateNestedTestStructure(testStructureDir);
+            _options.BlobType = blobtype;
+            _options.PreserveDirectoryStructure = false;
+
+            if (blobtype is AzureBlobType.Page)
+                _options.ResizeFile = true;
+
+            _input.SourceType = UploadSourceType.Directory;
+            _input.SourceDirectory = testStructureDir;
+            _input.SourceFile = default;
+            _input.BlobFolderName = "MyPrefix";
+
+            var container = GetBlobContainer(TestHelper.ConnectionString, _containerName);
+            var result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
+            Assert.IsTrue(result.Success);
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/MyPrefix/NestedStructure/level1file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("MyPrefix/NestedStructure/level1file.txt").ExistsAsync(),
+                "MyPrefix/NestedStructure/level1file.txt should exist");
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/MyPrefix/sub1/level2file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("MyPrefix/sub1/level2file.txt").ExistsAsync(),
+                "MyPrefix/sub1/level2file.txt should exist");
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/MyPrefix/sub2/level3file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("MyPrefix/sub2/level3file.txt").ExistsAsync(),
+                "MyPrefix/sub2/level3file.txt should exist");
+
+            await CleanUp();
+            TestSetup();
+        }
+    }
+
+    [Test]
     public async Task UploadBlob_TestEncoding()
     {
         var encodings = new List<FileEncoding>()

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.Tests/UnitTests.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.Tests/UnitTests.cs
@@ -572,6 +572,211 @@ public class UnitTests
     }
 
     [Test]
+    public async Task UploadDirectory_PreserveStructure_True()
+    {
+        var testStructureDir = Path.Combine(_testFileDir, "NestedStructure");
+        CreateNestedTestStructure(testStructureDir);
+
+        foreach (var blobtype in _blobtypes)
+        {
+            _options.BlobType = blobtype;
+            _options.PreserveDirectoryStructure = true;
+
+            if (blobtype is AzureBlobType.Page)
+                _options.ResizeFile = true;
+
+            _input.SourceType = UploadSourceType.Directory;
+            _input.SourceDirectory = testStructureDir;
+            var container = GetBlobContainer(TestHelper.ConnectionString, _containerName);
+            var result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
+            Assert.IsTrue(result.Success);
+
+            // Verify nested structure is preserved
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/level1file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("level1file.txt").ExistsAsync(),
+                "level1file.txt should exist at root");
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/sub1/level2file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("sub1/level2file.txt").ExistsAsync(),
+                "sub1/level2file.txt should exist with subdirectory");
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/sub1/sub2/level3file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("sub1/sub2/level3file.txt").ExistsAsync(),
+                "sub1/sub2/level3file.txt should exist with nested subdirectories");
+
+            await CleanUp();
+            TestSetup();
+            CreateNestedTestStructure(testStructureDir);
+
+            if (blobtype is AzureBlobType.Page)
+                _options.ResizeFile = true;
+
+            // OAuth
+            _input.SourceType = UploadSourceType.Directory;
+            _input.SourceDirectory = testStructureDir;
+            _input.SourceFile = default;
+            _connection.AuthenticationMethod = ConnectionMethod.OAuth2;
+            container = GetBlobContainer(TestHelper.ConnectionString, _containerName);
+            _options.PreserveDirectoryStructure = true;
+            result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(await container.GetBlobClient("level1file.txt").ExistsAsync(), "OAuth");
+            Assert.IsTrue(await container.GetBlobClient("sub1/level2file.txt").ExistsAsync(), "OAuth");
+            Assert.IsTrue(await container.GetBlobClient("sub1/sub2/level3file.txt").ExistsAsync(), "OAuth");
+
+            await CleanUp();
+            TestSetup();
+            CreateNestedTestStructure(testStructureDir);
+
+            if (blobtype is AzureBlobType.Page)
+                _options.ResizeFile = true;
+
+            // SAS token
+            _input.SourceType = UploadSourceType.Directory;
+            _input.SourceDirectory = testStructureDir;
+            _input.SourceFile = default;
+            _connection.AuthenticationMethod = ConnectionMethod.SasToken;
+            _input.ContainerName = _container;
+            container = GetBlobContainer(TestHelper.ConnectionString, _container);
+            _options.PreserveDirectoryStructure = true;
+            result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
+            Assert.IsTrue(result.Success);
+            Assert.IsTrue(await container.GetBlobClient("level1file.txt").ExistsAsync(), "SAS token");
+            Assert.IsTrue(await container.GetBlobClient("sub1/level2file.txt").ExistsAsync(), "SAS token");
+            Assert.IsTrue(await container.GetBlobClient("sub1/sub2/level3file.txt").ExistsAsync(), "SAS token");
+
+            await CleanUp();
+            TestSetup();
+            CreateNestedTestStructure(testStructureDir);
+        }
+    }
+
+    [Test]
+    public async Task UploadDirectory_PreserveStructure_False()
+    {
+        var testStructureDir = Path.Combine(_testFileDir, "NestedStructure");
+        CreateNestedTestStructure(testStructureDir);
+
+        foreach (var blobtype in _blobtypes)
+        {
+            _options.BlobType = blobtype;
+            _options.PreserveDirectoryStructure = false;
+
+            if (blobtype is AzureBlobType.Page)
+                _options.ResizeFile = true;
+
+            // Connection string
+            _input.SourceType = UploadSourceType.Directory;
+            _input.SourceDirectory = testStructureDir;
+            _input.SourceFile = default;
+            _input.BlobFolderName = null;
+            var container = GetBlobContainer(TestHelper.ConnectionString, _containerName);
+            var result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
+            Assert.IsTrue(result.Success);
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/NestedStructure/level1file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("NestedStructure/level1file.txt").ExistsAsync(),
+                "level1file.txt should exist under NestedStructure only");
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/sub1/level2file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("sub1/level2file.txt").ExistsAsync(),
+                "level2file.txt should exist under sub1 only (parent dir, not nested)");
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/sub2/level3file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("sub2/level3file.txt").ExistsAsync(),
+                "level3file.txt should exist under sub2 only (direct parent, not nested)");
+
+            await CleanUp();
+            TestSetup();
+            CreateNestedTestStructure(testStructureDir);
+
+            if (blobtype is AzureBlobType.Page)
+                _options.ResizeFile = true;
+
+            // OAuth
+            _input.SourceType = UploadSourceType.Directory;
+            _input.SourceDirectory = testStructureDir;
+            _input.SourceFile = default;
+            _connection.AuthenticationMethod = ConnectionMethod.OAuth2;
+            container = GetBlobContainer(TestHelper.ConnectionString, _containerName);
+            _options.PreserveDirectoryStructure = false;
+            result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
+            Assert.IsTrue(result.Success, "OAuth");
+            Assert.IsTrue(await container.GetBlobClient("NestedStructure/level1file.txt").ExistsAsync(), "OAuth");
+            Assert.IsTrue(await container.GetBlobClient("sub1/level2file.txt").ExistsAsync(), "OAuth");
+            Assert.IsTrue(await container.GetBlobClient("sub2/level3file.txt").ExistsAsync(), "OAuth");
+
+            await CleanUp();
+            TestSetup();
+            CreateNestedTestStructure(testStructureDir);
+
+            if (blobtype is AzureBlobType.Page)
+                _options.ResizeFile = true;
+
+            // SAS token
+            _input.SourceType = UploadSourceType.Directory;
+            _input.SourceDirectory = testStructureDir;
+            _input.SourceFile = default;
+            _connection.AuthenticationMethod = ConnectionMethod.SasToken;
+            _input.ContainerName = _container;
+            container = GetBlobContainer(TestHelper.ConnectionString, _container);
+            _options.PreserveDirectoryStructure = false;
+            result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
+            Assert.IsTrue(result.Success, "SAS token");
+            Assert.IsTrue(await container.GetBlobClient("NestedStructure/level1file.txt").ExistsAsync(), "SAS token");
+            Assert.IsTrue(await container.GetBlobClient("sub1/level2file.txt").ExistsAsync(), "SAS token");
+            Assert.IsTrue(await container.GetBlobClient("sub2/level3file.txt").ExistsAsync(), "SAS token");
+
+            await CleanUp();
+            TestSetup();
+            CreateNestedTestStructure(testStructureDir);
+        }
+    }
+
+    [Test]
+    public async Task UploadDirectory_PreserveStructure_True_WithBlobFolderName()
+    {
+        // Tests PreserveDirectoryStructure=true with BlobFolderName prefix
+        var testStructureDir = Path.Combine(_testFileDir, "NestedStructure");
+        CreateNestedTestStructure(testStructureDir);
+
+        foreach (var blobtype in _blobtypes)
+        {
+            _options.BlobType = blobtype;
+            _options.PreserveDirectoryStructure = true;
+
+            if (blobtype is AzureBlobType.Page)
+                _options.ResizeFile = true;
+
+            // Connection string
+            _input.SourceType = UploadSourceType.Directory;
+            _input.SourceDirectory = testStructureDir;
+            _input.SourceFile = default;
+            _input.BlobFolderName = "MyPrefix";
+            var container = GetBlobContainer(TestHelper.ConnectionString, _containerName);
+            var result = await AzureBlobStorage.UploadBlob(_input, _connection, _options, default);
+            Assert.IsTrue(result.Success);
+
+            // Verify structure is preserved with prefix
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/MyPrefix/level1file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("MyPrefix/level1file.txt").ExistsAsync(),
+                "MyPrefix/level1file.txt should exist");
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/MyPrefix/sub1/level2file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("MyPrefix/sub1/level2file.txt").ExistsAsync(),
+                "MyPrefix/sub1/level2file.txt should exist");
+
+            Assert.IsTrue(result.Data.ContainsValue($"{container.Uri}/MyPrefix/sub1/sub2/level3file.txt"));
+            Assert.IsTrue(await container.GetBlobClient("MyPrefix/sub1/sub2/level3file.txt").ExistsAsync(),
+                "MyPrefix/sub1/sub2/level3file.txt should exist");
+
+            await CleanUp();
+            TestSetup();
+            CreateNestedTestStructure(testStructureDir);
+        }
+    }
+
+    [Test]
     public async Task UploadBlob_TestEncoding()
     {
         var encodings = new List<FileEncoding>()
@@ -988,5 +1193,24 @@ public class UnitTests
         var content = await reader.ReadToEndAsync();
 
         return content == expected;
+    }
+
+    private void CreateNestedTestStructure(string baseDir)
+    {
+        // Create nested directory structure for testing
+        Directory.CreateDirectory(baseDir);
+
+        // Level 1: file at base
+        File.WriteAllText(Path.Combine(baseDir, "level1file.txt"), "Level 1 content");
+
+        // Level 2: file in sub1
+        var sub1Dir = Path.Combine(baseDir, "sub1");
+        Directory.CreateDirectory(sub1Dir);
+        File.WriteAllText(Path.Combine(sub1Dir, "level2file.txt"), "Level 2 content");
+
+        // Level 3: file in sub1/sub2
+        var sub2Dir = Path.Combine(sub1Dir, "sub2");
+        Directory.CreateDirectory(sub2Dir);
+        File.WriteAllText(Path.Combine(sub2Dir, "level3file.txt"), "Level 3 content");
     }
 }

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Definitions/Enums.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Definitions/Enums.cs
@@ -13,6 +13,8 @@ public enum UploadSourceType
 
 /// <summary>
 /// Action taken when a blob already exists.
+/// NOTE: If Options.PreserveDirectoryStructure is false, there can occur file collisions resolved by this option during upload.
+/// It can happen when files with the same name exist in different subdirectories.
 /// </summary>
 public enum OnExistingFile
 {

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Definitions/Options.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Definitions/Options.cs
@@ -95,4 +95,13 @@ public class Options
     /// <example>64</example>
     [DefaultValue(64)]
     public int ParallelOperations { get; set; }
+
+    /// <summary>
+    /// When uploading a directory, preserve the source directory structure in the destination.
+    /// True: Creates subdirectories in blob storage to match the source structure.
+    /// False: Uploads all files with only their parent directory name (legacy behavior).
+    /// </summary>
+    /// <example>false</example>
+    [DefaultValue(false)]
+    public bool PreserveDirectoryStructure { get; set; }
 }

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.csproj
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net8.0</TargetFramework>
-        <Version>4.1.0</Version>
+        <Version>4.2.0</Version>
         <Authors>Frends</Authors>
         <Copyright>Frends</Copyright>
         <Company>Frends</Company>

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/UploadBlob.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/UploadBlob.cs
@@ -92,10 +92,10 @@ public static class AzureBlobStorage
                         }
                         else
                         {
-                            var parentDirectory = Path.GetFileName(Path.GetDirectoryName(file.ToString()));
-                            relativeBlobPath = string.IsNullOrEmpty(input.BlobFolderName)
-                                ? Path.Combine(parentDirectory, fileName)
-                                : fileName;
+                            var parentDirectory = Path.GetFileName(file.DirectoryName);
+                            relativeBlobPath = string.IsNullOrEmpty(parentDirectory)
+                                ? fileName
+                                : Path.Combine(parentDirectory, fileName);
                         }
 
                         var withDir = string.IsNullOrEmpty(input.BlobFolderName)

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/UploadBlob.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/UploadBlob.cs
@@ -92,10 +92,10 @@ public static class AzureBlobStorage
                         }
                         else
                         {
-                            var parentDirectory = Path.GetFileName(file.DirectoryName);
-                            relativeBlobPath = string.IsNullOrEmpty(parentDirectory)
-                                ? fileName
-                                : Path.Combine(parentDirectory, fileName);
+                            var parentDirectory = Path.GetFileName(Path.GetDirectoryName(file.ToString()));
+                            relativeBlobPath = string.IsNullOrEmpty(input.BlobFolderName)
+                                ? Path.Combine(parentDirectory, fileName)
+                                : fileName;
                         }
 
                         var withDir = string.IsNullOrEmpty(input.BlobFolderName)

--- a/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/UploadBlob.cs
+++ b/Frends.AzureBlobStorage.UploadBlob/Frends.AzureBlobStorage.UploadBlob/UploadBlob.cs
@@ -80,10 +80,27 @@ public static class AzureBlobStorage
                         if (input.Compress)
                             fileName = RenameFile(fileName, input.Compress, file);
 
-                        var parentDirectory = Path.GetFileName(Path.GetDirectoryName(file.ToString()));
+                        string relativeBlobPath;
+
+                        if (options.PreserveDirectoryStructure)
+                        {
+                            var relativePath = Path.GetRelativePath(dir, file.FullName);
+                            var relativeDirectory = Path.GetDirectoryName(relativePath);
+                            relativeBlobPath = string.IsNullOrEmpty(relativeDirectory) || relativeDirectory == "."
+                                ? fileName
+                                : Path.Combine(relativeDirectory, fileName);
+                        }
+                        else
+                        {
+                            var parentDirectory = Path.GetFileName(Path.GetDirectoryName(file.ToString()));
+                            relativeBlobPath = string.IsNullOrEmpty(input.BlobFolderName)
+                                ? Path.Combine(parentDirectory, fileName)
+                                : fileName;
+                        }
+
                         var withDir = string.IsNullOrEmpty(input.BlobFolderName)
-                            ? Path.Combine(parentDirectory, fileName)
-                            : Path.Combine(input.BlobFolderName, fileName);
+                            ? relativeBlobPath
+                            : Path.Combine(input.BlobFolderName, relativeBlobPath);
 
                         blobName = withDir.Replace("\\", "/");
 


### PR DESCRIPTION

## Review Checklist

- [ ] Task version updated (x.x.0)
- [ ] CHANGELOG.md updated
- [ ] Solution builds
- [ ] Warnings resolved (if possible)
- [ ] Typos resolved
- [ ] Tests cover new code
- [ ] Description how to run tests locally added to README.md (if needed)
- [ ] All tests pass locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to preserve directory structure when uploading directories to Azure Blob Storage; nested folder hierarchies are maintained (disabled by default for backward compatibility).

* **Tests**
  * Added comprehensive tests covering directory uploads with and without structure preservation across authentication modes.

* **Chores**
  * Bumped package version to 4.2.0.

* **Documentation**
  * Added changelog entry and clarified doc note about filename collisions when preservation is disabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/FrendsPlatform/Frends.AzureBlobStorage/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->